### PR TITLE
fix: typo

### DIFF
--- a/xApiHmac.js
+++ b/xApiHmac.js
@@ -257,7 +257,7 @@ xeggexApi.prototype.balances = function() {
 
 xeggexApi.prototype.createOrder = function(symbol, side, quantity, price, type = 'limit', userProvidedId = null, strictValidate = false) {
     let url = new URL(baseUrl+'/createorder');
-    let body = {}
+    let body = {
 	  "userProvidedId": userProvidedId,
 	  "symbol": symbol,
 	  "side": side,


### PR DESCRIPTION
fix typo issue:
```
node index.js
/home/user/xeggex/xeggexapinodehmac/xApiHmac.js:261
          "userProvidedId": userProvidedId,
                          ^

SyntaxError: Unexpected token ':'
    at wrapSafe (internal/modules/cjs/loader.js:915:16)
    at Module._compile (internal/modules/cjs/loader.js:963:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/home/user/xeggex/xeggexapinodehmac/index.js:1:16)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
```